### PR TITLE
Add severity and category data for each message type and pass it along to MessageIcon

### DIFF
--- a/js/components/Message/MessageBody.js
+++ b/js/components/Message/MessageBody.js
@@ -22,7 +22,7 @@ function MessageBody(props) {
   return (
     <div className="message" data-category={category} data-severity={severity}>
       <MessageTimestamp timestamp={timeStamp} />
-      <MessageIcon />
+      <MessageIcon severity={severity} />
       {prefix}
       <span className="message-body-wrapper message-body devtools-monospace">
         <span>

--- a/js/utils/MessageDispatcherUtils.js
+++ b/js/utils/MessageDispatcherUtils.js
@@ -1,21 +1,84 @@
 // Temporary utility. Once this is integrated back in the code base, this will
 // likely live in different parts of the system.
 
+// The various categories of messages.
+const CATEGORY_NETWORK = 0;
+const CATEGORY_CSS = 1;
+const CATEGORY_JS = 2;
+const CATEGORY_WEBDEV = 3;
+const CATEGORY_INPUT = 4;
+const CATEGORY_OUTPUT = 5;
+const CATEGORY_SECURITY = 6;
+const CATEGORY_SERVER = 7;
+
+// The fragment of a CSS class name that identifies each category.
+const CATEGORY_CLASS_FRAGMENTS = [
+  "network",
+  "cssparser",
+  "exception",
+  "console",
+  "input",
+  "output",
+  "security",
+  "server",
+];
+
+// The possible message severities.
+const SEVERITY_ERROR = 0;
+const SEVERITY_WARNING = 1;
+const SEVERITY_INFO = 2;
+const SEVERITY_LOG = 3;
+
+// The fragment of a CSS class name that identifies each severity.
+const SEVERITY_CLASS_FRAGMENTS = [
+  "error",
+  "warn",
+  "info",
+  "log",
+];
+
+// A mapping from the console API log event levels to the Web Console
+// severities.
+const LEVELS = {
+  error: SEVERITY_ERROR,
+  exception: SEVERITY_ERROR,
+  assert: SEVERITY_ERROR,
+  warn: SEVERITY_WARNING,
+  info: SEVERITY_INFO,
+  log: SEVERITY_LOG,
+  trace: SEVERITY_LOG,
+  table: SEVERITY_LOG,
+  debug: SEVERITY_LOG,
+  dir: SEVERITY_LOG,
+  dirxml: SEVERITY_LOG,
+  group: SEVERITY_LOG,
+  groupCollapsed: SEVERITY_LOG,
+  groupEnd: SEVERITY_LOG,
+  time: SEVERITY_LOG,
+  timeEnd: SEVERITY_LOG,
+  count: SEVERITY_LOG
+};
+
 export function prepareMessageInput(messageType, packet) {
   let message;
 
   switch (messageType) {
     case "ConsoleGeneric":
-      message = packet.message
+      message = packet.message;
+      message.severity = SEVERITY_CLASS_FRAGMENTS[LEVELS[message.level]];
       break;
     case "JavaScriptEvalOutput":
       message = packet.result;
       // The timestamp isn't attached to the 'result' portion of the packet,
       // and also it's all lower case from this packet for whatever reason.
       message.timeStamp = packet.timestamp;
+      message.severity = "log";
+      message.category = CATEGORY_CLASS_FRAGMENTS[CATEGORY_OUTPUT];
       break;
     case "ConsoleService":
       message = packet.pageError;
+      // @TODO use proper severity for console service messages
+      message.severity = "error";
       break;
   }
 


### PR DESCRIPTION
This copies some code from the current webconsole into MessageDispatcherUtils.js.  I don't know that it will be the final resting place of this code but it at least lets the frontend act as if these properties are consistently coming through the various different packet formats.