### PR TITLE
Set up message repeating (fixes #20)

### DIFF
--- a/js/components/Message/MessageRepeat.js
+++ b/js/components/Message/MessageRepeat.js
@@ -2,8 +2,8 @@ import React, { PropTypes } from "react";
 
 function MessageRepeat(props) {
   return (
-    <span value="1" className="message-repeats">
-      // @TODO implement
+    <span value="{props.repeats}" className="message-repeats">
+      {props.repeats}
     </span>
   );
 }

--- a/js/components/Message/Types/ConsoleGeneric.js
+++ b/js/components/Message/Types/ConsoleGeneric.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from "react";
 import MessageBody from "../MessageBody";
+import MessageRepeat from "../MessageRepeat";
 import MessageLocation from "../MessageLocation";
 import BodyPieces from "../BodyPieces";
 
@@ -13,8 +14,8 @@ ConsoleGeneric.propTypes = {
 
 function ConsoleGeneric(props) {
   // @TODO actually handle repeat and location (and add prop definitions)
-  let repeat = props.repeat ? <MessageRepeat /> : "";
-  let location = props.location ? <MessageLocation target="jsdebugger" /> : "";
+  let repeat = props.message.repeats ? <MessageRepeat repeats={props.message.repeats} /> : "";
+  let location = props.message.location ? <MessageLocation target="jsdebugger" /> : "";
 
   return (
     <MessageBody message={props.message} isFlexed>

--- a/js/reducers/homeReducer.js
+++ b/js/reducers/homeReducer.js
@@ -10,10 +10,64 @@ function homeReducer(state = initialState, action) {
     case MESSAGE_ADD:
       const messages = state.messages;
       messages.push(action.message);
-      return Object.assign({}, state, { messages });
+      return Object.assign({}, state, {
+        messages: removeRepeats(messages)
+      });
     default:
       return state;
   }
+}
+
+// Any subsequent duplicate messages should be marked as 'repeated'
+// and removed from the array, so a badge can display next to it instead
+// of repeating the messages in the output.
+// Note that only certain message types allow repeating.
+function removeRepeats(messages) {
+  let lastRepeatID = null;
+  let lastRepeatedMessage = null;
+
+  messages.forEach((message, i) => {
+    // Only try to repeat messages that support this feature
+    if (!message.allowRepeating) {
+      lastRepeatedMessage = lastRepeatID = null;
+      return;
+    }
+
+    // We could be explicit about what we care about in the repeat ID,
+    // or we could just stringify the entire message (sans-timestamp).
+    // Choosing this approach for now because it feels like it'd have less
+    // false-positive repeats.
+    if (!message._repeatID) {
+      let clonedMessage = JSON.parse(JSON.stringify(message));
+      delete clonedMessage.timeStamp;
+      message._repeatID = JSON.stringify(clonedMessage);
+    }
+
+    // Alternatively, here is the explicit approach:
+    // message._repeatID = message._repeatID || JSON.stringify({
+    //   category: message.category,
+    //   severity: message.severity,
+    //   prefix: message.prefix,
+    //   private: message.private,
+    //   location: message.location,
+    //   arguments: message.arguments,
+    // });
+
+    if (message._repeatID === lastRepeatID) {
+      if (!lastRepeatedMessage.repeats) {
+        lastRepeatedMessage.repeats = 2;
+      } else {
+        lastRepeatedMessage.repeats++;
+      }
+
+      messages[i] = null;
+    } else {
+      lastRepeatedMessage = message;
+      lastRepeatID = message._repeatID;
+    }
+  });
+
+  return messages.filter(m => m);
 }
 
 export default homeReducer;

--- a/js/utils/MessageDispatcherUtils.js
+++ b/js/utils/MessageDispatcherUtils.js
@@ -6,7 +6,8 @@ export function prepareMessageInput(messageType, packet) {
 
   switch (messageType) {
     case "ConsoleGeneric":
-      message = packet.message
+      message = packet.message;
+      message.allowRepeating = true;
       break;
     case "JavaScriptEvalOutput":
       message = packet.result;
@@ -20,5 +21,8 @@ export function prepareMessageInput(messageType, packet) {
   }
 
   message.messageType = messageType;
-  return message
+
+  // Clone the message (needed since our test data is exporting objects directly).
+  // Won't be needed when actual RDP packets are coming in
+  return JSON.parse(JSON.stringify(message))
 }


### PR DESCRIPTION
This is one approach to implementing message repeating.  We manage this in the store by completely deleting messages out of the array that gets set as state if they are determined to be repeats.  Also set a property on the first message in a set of repeats with the count.  This is nice because it keeps the messages array short and we don't need to re-process known duplicates.