### PR TITLE
Directly create messages from RDP packets

### DIFF
--- a/js/components/Message/MessageStacktrace.js
+++ b/js/components/Message/MessageStacktrace.js
@@ -7,6 +7,10 @@ MessageStacktrace.propTypes = {
 function MessageStacktrace(props) {
   // @TODO need to make the stacktrace collapsible
 
+  if (!props.stacktrace) {
+    return (<div />);
+  }
+
   let pieces = props.stacktrace.map(function(trace, i) {
     // Stacktraces don't ever change order so we can use the index
     // as a unique ID to prevent the warning: https://fb.me/react-warning-keys

--- a/js/components/TempTester.js
+++ b/js/components/TempTester.js
@@ -20,6 +20,9 @@ class TempTester extends Component {
         <button data-messagetype="ConsoleService" onClick={this.props.outputMessages}>
           Simulate Console Service Message (Page Error)
         </button>
+        <button onClick={this.props.outputMessageStream}>
+          Simulate a bunch of messages
+        </button>
       </div>
     );
   }
@@ -33,7 +36,36 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = (dispatch) => {
+
+  function dispatchMessageFromRDP(packet) {
+    let {type} = packet;
+    if (type === "consoleAPICall") {
+      let message = prepareMessageInput("ConsoleGeneric", packet);
+      dispatch(messageAdd(message))
+    }
+    if (type === "pageError") {
+      let message = prepareMessageInput("ConsoleService", packet);
+      dispatch(messageAdd(message))
+    }
+    if (type === "evaluationResult") {
+      let message = prepareMessageInput("JavaScriptEvalOutput", packet);
+      dispatch(messageAdd(message))
+    }
+    if (type === "networkEvent") {
+      // @TODO: Implement network event log
+    }
+    if (type === "networkEventUpdate") {
+      // @TODO: Implement network event log
+    }
+  }
+
   return {
+    outputMessageStream: () => {
+      let messages = data.MessageStream();
+      for (var i = 0; i < messages.length; i++) {
+        dispatchMessageFromRDP(messages[i]);
+      }
+    },
     outputMessages: (event) => {
       let {messagetype, objecttype, nummessages} = event.target.dataset;
       if (!nummessages) {
@@ -42,8 +74,7 @@ const mapDispatchToProps = (dispatch) => {
 
       let packet = objecttype ? data[messagetype][objecttype] : data[messagetype];
       for (var i = 0; i < nummessages; i++) {
-        let message = prepareMessageInput(messagetype, packet);
-        dispatch(messageAdd(message));
+        dispatchMessageFromRDP(packet);
       }
     },
   };

--- a/test/data/mock-messages/MessageStream.js
+++ b/test/data/mock-messages/MessageStream.js
@@ -1,0 +1,3056 @@
+
+export default function() {
+
+return [
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "blazblaz",
+        {
+          "type": "object",
+          "class": "DOMRect",
+          "actor": "server1.conn0.child1/obj37",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {},
+            "ownPropertiesLength": 0,
+            "safeGetterValues": {
+              "x": {
+                "getterValue": 10,
+                "getterPrototypeLevel": 1,
+                "enumerable": true,
+                "writable": true
+              },
+              "y": {
+                "getterValue": 43.19999694824219,
+                "getterPrototypeLevel": 1,
+                "enumerable": true,
+                "writable": true
+              },
+              "width": {
+                "getterValue": 105.18333435058594,
+                "getterPrototypeLevel": 1,
+                "enumerable": true,
+                "writable": true
+              },
+              "height": {
+                "getterValue": 19.5,
+                "getterPrototypeLevel": 1,
+                "enumerable": true,
+                "writable": true
+              },
+              "top": {
+                "getterValue": 43.19999694824219,
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "right": {
+                "getterValue": 115.18333435058594,
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "bottom": {
+                "getterValue": 62.69999694824219,
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "left": {
+                "getterValue": 10,
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              }
+            }
+          }
+        }
+      ],
+      "columnNumber": 5,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.js",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 5,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244820998,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foocount"
+      ],
+      "columnNumber": 5,
+      "counter": {
+        "count": 1,
+        "label": "foocount"
+      },
+      "filename": "http://localhost/devtools-demos/console/all.js",
+      "functionName": "",
+      "groupName": "",
+      "level": "count",
+      "lineNumber": 6,
+      "private": false,
+      "timeStamp": 1456244821002,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "pageError",
+    "pageError": {
+      "errorMessage": "SyntaxError: An invalid or illegal string was specified",
+      "sourceName": "http://localhost/devtools-demos/console/all.html",
+      "lineText": "",
+      "lineNumber": 168,
+      "columnNumber": 0,
+      "category": "content javascript",
+      "timeStamp": 1456244820998,
+      "warning": false,
+      "error": false,
+      "exception": true,
+      "strict": false,
+      "info": false,
+      "private": false,
+      "stacktrace": null
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "pageError",
+    "pageError": {
+      "errorMessage": "TypeError: foobarObject.intern is not a function",
+      "sourceName": "http://localhost/devtools-demos/console/all.html",
+      "lineText": "",
+      "lineNumber": 186,
+      "columnNumber": 11,
+      "category": "content javascript",
+      "timeStamp": 1456244820998,
+      "warning": false,
+      "error": false,
+      "exception": true,
+      "strict": false,
+      "info": false,
+      "private": false,
+      "stacktrace": [
+        {
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "lineNumber": 186,
+          "columnNumber": 11,
+          "functionName": null
+        }
+      ]
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "pageError",
+    "pageError": {
+      "errorMessage": "TypeError: ev.preventBubble is not a function",
+      "sourceName": "http://localhost/devtools-demos/console/all.js",
+      "lineText": "",
+      "lineNumber": 7,
+      "columnNumber": 5,
+      "category": "content javascript",
+      "timeStamp": 1456244821004,
+      "warning": false,
+      "error": false,
+      "exception": true,
+      "strict": false,
+      "info": false,
+      "private": false,
+      "stacktrace": [
+        {
+          "filename": "http://localhost/devtools-demos/console/all.js",
+          "lineNumber": 7,
+          "columnNumber": 5,
+          "functionName": null
+        }
+      ]
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "time",
+      "lineNumber": 192,
+      "private": false,
+      "timeStamp": 1456244822401,
+      "timer": {
+        "name": "foo",
+        "started": 22920.675
+      },
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo ",
+        " zuzu ",
+        " bla bla"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 194,
+      "private": false,
+      "styles": [
+        {
+          "type": "null"
+        },
+        "color:red;background:cyan",
+        "color: blue"
+      ],
+      "timeStamp": 1456244822402,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo ",
+        " zuzu ",
+        " bla bla"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 195,
+      "private": false,
+      "styles": [
+        "color:pink",
+        "color:red;font-size:1.3em",
+        "color: blue"
+      ],
+      "timeStamp": 1456244822403,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "background image"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 196,
+      "private": false,
+      "styles": [
+        "color:green;font-weight:bold;background:blue url('data:image/gif;base64,R0lGODlhAQABAPAAAP8AAP///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==')"
+      ],
+      "timeStamp": 1456244822404,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo",
+        "bar",
+        "boom"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 197,
+      "private": false,
+      "styles": [
+        {
+          "type": "null"
+        },
+        "color:blue",
+        "color:green"
+      ],
+      "timeStamp": 1456244822406,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo test zoom",
+        "bar 250909063 lolz",
+        "boom",
+        {
+          "type": "object",
+          "class": "Window",
+          "actor": "server1.conn0.child1/obj38",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 786,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/all.html"
+          }
+        },
+        "omg",
+        "red"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 198,
+      "private": false,
+      "styles": [
+        {
+          "type": "null"
+        },
+        "color:blue",
+        "color:green;font-weight:bold",
+        {
+          "type": "null"
+        },
+        {
+          "type": "null"
+        },
+        "color:red;font-size:2em"
+      ],
+      "timeStamp": 1456244822407,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "bad boy"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 199,
+      "private": false,
+      "styles": [
+        "font:1.4em arial; padding:6px; position:absolute; top:0; left:0; background:cyan; width:10em; height: 0; overflow: hidden; text-decoration:underline; display: inline-block"
+      ],
+      "timeStamp": 1456244822428,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foobar",
+        "bazbaz",
+        {
+          "type": "object",
+          "class": "Window",
+          "actor": "server1.conn0.child1/obj39",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 786,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/all.html"
+          }
+        },
+        "%comg",
+        "color:blue"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "info",
+      "lineNumber": 200,
+      "private": false,
+      "styles": [
+        {
+          "type": "null"
+        },
+        "color:green"
+      ],
+      "timeStamp": 1456244822429,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        {
+          "type": "object",
+          "class": "Object",
+          "actor": "server1.conn0.child1/obj40",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 3,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {
+              "testProp": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": "testValue"
+              },
+              "hello": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": 1
+              },
+              "world": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": true
+              }
+            },
+            "ownPropertiesLength": 3,
+            "safeGetterValues": {}
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "dir",
+      "lineNumber": 207,
+      "private": false,
+      "timeStamp": 1456244822430,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foocount"
+      ],
+      "columnNumber": 11,
+      "counter": {
+        "count": 2,
+        "label": "foocount"
+      },
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "count",
+      "lineNumber": 208,
+      "private": false,
+      "timeStamp": 1456244822433,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "tezt",
+        {
+          "type": "object",
+          "class": "Object",
+          "actor": "server1.conn0.child1/obj41",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 3,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {
+              "testProp": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": "testValue"
+              },
+              "hello": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": 1
+              },
+              "world": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": true
+              }
+            },
+            "ownPropertiesLength": 3,
+            "safeGetterValues": {}
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 209,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822434,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo repeat"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 251,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822435,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo repeat"
+      ],
+      "columnNumber": 37,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 251,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822436,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo repeat"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 252,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822436,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo repeat"
+      ],
+      "columnNumber": 37,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "error",
+      "lineNumber": 252,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822437,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 37,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "myEventHandler",
+          "language": 2,
+          "lineNumber": 252
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 211
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "log",
+        "click",
+        {
+          "type": "object",
+          "class": "MouseEvent",
+          "actor": "server1.conn0.child1/obj42",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "DOMEvent",
+            "type": "click",
+            "properties": {
+              "buttons": 0,
+              "clientX": 185,
+              "clientY": 52,
+              "layerX": 185,
+              "layerY": 738
+            },
+            "target": {
+              "type": "object",
+              "class": "HTMLButtonElement",
+              "actor": "server1.conn0.child1/obj43",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 0,
+              "preview": {
+                "kind": "DOMNode",
+                "nodeType": 1,
+                "nodeName": "button",
+                "attributes": {
+                  "id": "consoleAPI"
+                },
+                "attributesLength": 1
+              }
+            }
+          }
+        }
+      ],
+      "columnNumber": 24,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 254,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822437,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "console log result",
+        {
+          "type": "undefined"
+        }
+      ],
+      "columnNumber": 20,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 256,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822438,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "console log result 2",
+        {
+          "type": "undefined"
+        }
+      ],
+      "columnNumber": 20,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 267,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822439,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "console log result 3",
+        {
+          "type": "undefined"
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 269,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822439,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "info click"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "info",
+      "lineNumber": 271,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822440,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "error click"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "error",
+      "lineNumber": 272,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822441,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "myEventHandler",
+          "language": 2,
+          "lineNumber": 272
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 211
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "warn click"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "warn",
+      "lineNumber": 273,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822441,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "error omg aloha ",
+        {
+          "type": "object",
+          "class": "HTMLBodyElement",
+          "actor": "server1.conn0.child1/obj44",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "DOMNode",
+            "nodeType": 1,
+            "nodeName": "body",
+            "attributes": {
+              "class": "header"
+            },
+            "attributesLength": 1
+          }
+        },
+        " 1068 265 3.141593 %a",
+        "zuzu",
+        {
+          "type": "null"
+        },
+        {
+          "type": "undefined"
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "error",
+      "lineNumber": 274,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822441,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "myEventHandler",
+          "language": 2,
+          "lineNumber": 274
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 211
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "exception",
+        {
+          "type": "object",
+          "class": "Error",
+          "actor": "server1.conn0.child1/obj45",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 4,
+          "preview": {
+            "kind": "Error",
+            "name": "TypeError",
+            "message": "foobarObject.intern is not a function",
+            "stack": "lolz@http://localhost/devtools-demos/console/all.html:177:15\nlolz2@http://localhost/devtools-demos/console/all.html:180:15\n@http://localhost/devtools-demos/console/all.html:182:13\nEventListener.handleEvent*@http://localhost/devtools-demos/console/all.html:170:9\n@http://localhost/devtools-demos/console/all.html:138:8\n",
+            "fileName": "http://localhost/devtools-demos/console/all.html",
+            "lineNumber": 177,
+            "columnNumber": 15
+          }
+        }
+      ],
+      "columnNumber": 13,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "exception",
+      "lineNumber": 278,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822443,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 13,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "myEventHandler",
+          "language": 2,
+          "lineNumber": 278
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 211
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "debug",
+        "click",
+        {
+          "type": "object",
+          "class": "MouseEvent",
+          "actor": "server1.conn0.child1/obj46",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "DOMEvent",
+            "type": "click",
+            "properties": {
+              "buttons": 0,
+              "clientX": 185,
+              "clientY": 52,
+              "layerX": 185,
+              "layerY": 738
+            },
+            "target": {
+              "type": "object",
+              "class": "HTMLButtonElement",
+              "actor": "server1.conn0.child1/obj47",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "ownPropertyLength": 0,
+              "preview": {
+                "kind": "DOMNode",
+                "nodeType": 1,
+                "nodeName": "button",
+                "attributes": {
+                  "id": "consoleAPI"
+                },
+                "attributesLength": 1
+              }
+            }
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "myEventHandler",
+      "groupName": "",
+      "level": "debug",
+      "lineNumber": 280,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822444,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        {
+          "type": "object",
+          "class": "StyleSheetList",
+          "actor": "server1.conn0.child1/obj48",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 3,
+          "preview": {
+            "kind": "ArrayLike",
+            "length": 3,
+            "items": [
+              {
+                "type": "object",
+                "class": "CSSStyleSheet",
+                "actor": "server1.conn0.child1/obj49",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 0,
+                "preview": {
+                  "kind": "ObjectWithURL",
+                  "url": "http://localhost/devtools-demos/shared/styles.css"
+                }
+              },
+              {
+                "type": "object",
+                "class": "CSSStyleSheet",
+                "actor": "server1.conn0.child1/obj50",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 0
+              },
+              {
+                "type": "object",
+                "class": "CSSStyleSheet",
+                "actor": "server1.conn0.child1/obj51",
+                "extensible": true,
+                "frozen": false,
+                "sealed": false,
+                "ownPropertyLength": 0,
+                "preview": {
+                  "kind": "ObjectWithURL",
+                  "url": "http://localhost/devtools-demos/console/test-unmatched.css?foobaz=foobar#lolz"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "class": "Console",
+          "actor": "server1.conn0.child1/obj52",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {
+              "__returnValue__": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": "test"
+              }
+            },
+            "ownPropertiesLength": 1,
+            "safeGetterValues": {}
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "dir",
+      "lineNumber": 213,
+      "private": false,
+      "timeStamp": 1456244822446,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foocount"
+      ],
+      "columnNumber": 11,
+      "counter": {
+        "count": 3,
+        "label": "foocount"
+      },
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe1",
+      "groupName": "",
+      "level": "count",
+      "lineNumber": 142,
+      "private": false,
+      "timeStamp": 1456244822449,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test stacktrace in console.assert",
+        {
+          "type": "object",
+          "class": "Window",
+          "actor": "server1.conn0.child1/obj53",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 786,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/all.html"
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "assert",
+      "lineNumber": 155,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822450,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 155
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1",
+          "language": 2,
+          "lineNumber": 143
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 214
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "trace",
+      "lineNumber": 156,
+      "private": false,
+      "timeStamp": 1456244822451,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 156
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1",
+          "language": 2,
+          "lineNumber": 143
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 214
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test stacktrace in console.error",
+        {
+          "type": "object",
+          "class": "HTMLBodyElement",
+          "actor": "server1.conn0.child1/obj54",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "DOMNode",
+            "nodeType": 1,
+            "nodeName": "body",
+            "attributes": {
+              "class": "header"
+            },
+            "attributesLength": 1
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "error",
+      "lineNumber": 157,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822452,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 157
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1",
+          "language": 2,
+          "lineNumber": 143
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 214
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test stacktrace in console.assert",
+        {
+          "type": "object",
+          "class": "Window",
+          "actor": "server1.conn0.child1/obj55",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 786,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/all.html"
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "assert",
+      "lineNumber": 155,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822453,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 155
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1b",
+          "language": 2,
+          "lineNumber": 147
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 215
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "trace",
+      "lineNumber": 156,
+      "private": false,
+      "timeStamp": 1456244822457,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 156
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1b",
+          "language": 2,
+          "lineNumber": 147
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 215
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test stacktrace in console.error",
+        {
+          "type": "object",
+          "class": "HTMLBodyElement",
+          "actor": "server1.conn0.child1/obj56",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "DOMNode",
+            "nodeType": 1,
+            "nodeName": "body",
+            "attributes": {
+              "class": "header"
+            },
+            "attributesLength": 1
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "error",
+      "lineNumber": 157,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822458,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 157
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1b",
+          "language": 2,
+          "lineNumber": 147
+        },
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 215
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test stacktrace in console.assert",
+        {
+          "type": "object",
+          "class": "Window",
+          "actor": "server1.conn0.child1/obj57",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 786,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/all.html"
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "assert",
+      "lineNumber": 155,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822459,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 155
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1b",
+          "language": 2,
+          "lineNumber": 147
+        },
+        {
+          "columnNumber": 34,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 215
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "trace",
+      "lineNumber": 156,
+      "private": false,
+      "timeStamp": 1456244822460,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 156
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1b",
+          "language": 2,
+          "lineNumber": 147
+        },
+        {
+          "columnNumber": 34,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 215
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test stacktrace in console.error",
+        {
+          "type": "object",
+          "class": "HTMLBodyElement",
+          "actor": "server1.conn0.child1/obj58",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "DOMNode",
+            "nodeType": 1,
+            "nodeName": "body",
+            "attributes": {
+              "class": "header"
+            },
+            "attributesLength": 1
+          }
+        }
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "foobarTraceMe3",
+      "groupName": "",
+      "level": "error",
+      "lineNumber": 157,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822461,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe3",
+          "language": 2,
+          "lineNumber": 157
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe2",
+          "language": 2,
+          "lineNumber": 151
+        },
+        {
+          "columnNumber": 18,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "foobarTraceMe1b",
+          "language": 2,
+          "lineNumber": 147
+        },
+        {
+          "columnNumber": 34,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 215
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test no repeat",
+        {
+          "type": "object",
+          "class": "Object",
+          "actor": "server1.conn0.child1/obj59",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {
+              "i": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": 0
+              }
+            },
+            "ownPropertiesLength": 1,
+            "safeGetterValues": {}
+          }
+        }
+      ],
+      "columnNumber": 13,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 220,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822462,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test no repeat",
+        {
+          "type": "object",
+          "class": "Object",
+          "actor": "server1.conn0.child1/obj60",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {
+              "i": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": 1
+              }
+            },
+            "ownPropertiesLength": 1,
+            "safeGetterValues": {}
+          }
+        }
+      ],
+      "columnNumber": 13,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 220,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822463,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test no repeat",
+        {
+          "type": "object",
+          "class": "Object",
+          "actor": "server1.conn0.child1/obj61",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 1,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {
+              "i": {
+                "configurable": true,
+                "enumerable": true,
+                "writable": true,
+                "value": 2
+              }
+            },
+            "ownPropertiesLength": 1,
+            "safeGetterValues": {}
+          }
+        }
+      ],
+      "columnNumber": 13,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 220,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822467,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test repeat",
+        0
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 223,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822468,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test repeat",
+        0
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 224,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822469,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test repeat",
+        2
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 225,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822469,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test repeat",
+        2
+      ],
+      "columnNumber": 42,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 225,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822470,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "test repeat",
+        0
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 226,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822470,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foocount"
+      ],
+      "columnNumber": 11,
+      "counter": {
+        "count": 4,
+        "label": "foocount"
+      },
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "count",
+      "lineNumber": 228,
+      "private": false,
+      "timeStamp": 1456244822471,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "false assert [object HTMLDocument]",
+        {
+          "type": "object",
+          "class": "Window",
+          "actor": "server1.conn0.child1/obj62",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 786,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/all.html"
+          }
+        },
+        "foo"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "assert",
+      "lineNumber": 232,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822471,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 232
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "falsy assert"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "assert",
+      "lineNumber": 233,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822473,
+      "timer": null,
+      "stacktrace": [
+        {
+          "columnNumber": 11,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 233
+        },
+        {
+          "asyncCause": "EventListener.handleEvent",
+          "columnNumber": 9,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 190
+        },
+        {
+          "columnNumber": 8,
+          "filename": "http://localhost/devtools-demos/console/all.html",
+          "functionName": "",
+          "language": 2,
+          "lineNumber": 138
+        }
+      ],
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo"
+      ],
+      "columnNumber": 24,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "timeEnd",
+      "lineNumber": 236,
+      "private": false,
+      "timeStamp": 1456244822473,
+      "timer": {
+        "duration": 72.29500000000189,
+        "name": "foo"
+      },
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "timeEnd result undefined"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 237,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822473,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "foo2"
+      ],
+      "columnNumber": 20,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "timeEnd",
+      "lineNumber": 239,
+      "private": false,
+      "timeStamp": 1456244822474,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "timeEnd2 result undefined"
+      ],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 240,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244822474,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "time",
+      "lineNumber": 242,
+      "private": false,
+      "timeStamp": 1456244822475,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [],
+      "columnNumber": 11,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "",
+      "groupName": "",
+      "level": "timeEnd",
+      "lineNumber": 243,
+      "private": false,
+      "timeStamp": 1456244822475,
+      "timer": null,
+      "workerType": "none",
+      "styles": [],
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/obj40",
+    "prototype": {
+      "type": "object",
+      "class": "Object",
+      "actor": "server1.conn0.child1/obj65",
+      "extensible": true,
+      "frozen": false,
+      "sealed": false,
+      "ownPropertyLength": 15,
+      "preview": {
+        "kind": "Object",
+        "ownProperties": {},
+        "ownPropertiesLength": 15,
+        "safeGetterValues": {}
+      }
+    },
+    "ownProperties": {
+      "testProp": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": true,
+        "value": "testValue"
+      },
+      "hello": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": true,
+        "value": 1
+      },
+      "world": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": true,
+        "value": true
+      }
+    },
+    "safeGetterValues": {}
+  },
+  {
+    "from": "server1.conn0.child1/obj48",
+    "prototype": {
+      "type": "object",
+      "class": "StyleSheetListPrototype",
+      "actor": "server1.conn0.child1/obj72",
+      "extensible": true,
+      "frozen": false,
+      "sealed": false,
+      "ownPropertyLength": 3,
+      "preview": {
+        "kind": "Object",
+        "ownProperties": {
+          "item": {
+            "configurable": true,
+            "enumerable": true,
+            "writable": true,
+            "value": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server1.conn0.child1/obj73",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "name": "item",
+              "displayName": "item"
+            }
+          },
+          "length": {
+            "configurable": true,
+            "enumerable": true,
+            "get": {
+              "type": "object",
+              "class": "Function",
+              "actor": "server1.conn0.child1/obj74",
+              "extensible": true,
+              "frozen": false,
+              "sealed": false,
+              "name": "get length",
+              "displayName": "get length"
+            },
+            "set": {
+              "type": "undefined"
+            }
+          }
+        },
+        "ownPropertiesLength": 3,
+        "safeGetterValues": {}
+      }
+    },
+    "ownProperties": {
+      "0": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": false,
+        "value": {
+          "type": "object",
+          "class": "CSSStyleSheet",
+          "actor": "server1.conn0.child1/obj66",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/shared/styles.css"
+          }
+        }
+      },
+      "1": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": false,
+        "value": {
+          "type": "object",
+          "class": "CSSStyleSheet",
+          "actor": "server1.conn0.child1/obj67",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "Object",
+            "ownProperties": {},
+            "ownPropertiesLength": 0,
+            "safeGetterValues": {
+              "ownerRule": {
+                "getterValue": {
+                  "type": "null"
+                },
+                "getterPrototypeLevel": 1,
+                "enumerable": true,
+                "writable": true
+              },
+              "cssRules": {
+                "getterValue": {
+                  "type": "object",
+                  "class": "CSSRuleList",
+                  "actor": "server1.conn0.child1/obj68",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 10,
+                  "preview": {
+                    "kind": "ArrayLike",
+                    "length": 10
+                  }
+                },
+                "getterPrototypeLevel": 1,
+                "enumerable": true,
+                "writable": true
+              },
+              "type": {
+                "getterValue": "text/css",
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "href": {
+                "getterValue": {
+                  "type": "null"
+                },
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "ownerNode": {
+                "getterValue": {
+                  "type": "object",
+                  "class": "HTMLStyleElement",
+                  "actor": "server1.conn0.child1/obj69",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 0,
+                  "preview": {
+                    "kind": "DOMNode",
+                    "nodeType": 1,
+                    "nodeName": "style",
+                    "attributes": {
+                      "type": "text/css"
+                    },
+                    "attributesLength": 1
+                  }
+                },
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "parentStyleSheet": {
+                "getterValue": {
+                  "type": "null"
+                },
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "title": {
+                "getterValue": "",
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "media": {
+                "getterValue": {
+                  "type": "object",
+                  "class": "MediaList",
+                  "actor": "server1.conn0.child1/obj70",
+                  "extensible": true,
+                  "frozen": false,
+                  "sealed": false,
+                  "ownPropertyLength": 0,
+                  "preview": {
+                    "kind": "ArrayLike",
+                    "length": 0
+                  }
+                },
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              },
+              "disabled": {
+                "getterValue": false,
+                "getterPrototypeLevel": 2,
+                "enumerable": true,
+                "writable": true
+              }
+            }
+          }
+        }
+      },
+      "2": {
+        "configurable": true,
+        "enumerable": true,
+        "writable": false,
+        "value": {
+          "type": "object",
+          "class": "CSSStyleSheet",
+          "actor": "server1.conn0.child1/obj71",
+          "extensible": true,
+          "frozen": false,
+          "sealed": false,
+          "ownPropertyLength": 0,
+          "preview": {
+            "kind": "ObjectWithURL",
+            "url": "http://localhost/devtools-demos/console/test-unmatched.css?foobaz=foobar#lolz"
+          }
+        }
+      }
+    },
+    "safeGetterValues": {
+      "length": {
+        "getterValue": 3,
+        "getterPrototypeLevel": 1,
+        "enumerable": true,
+        "writable": true
+      }
+    }
+  },
+  {
+    "highligter": {
+      "actor": "server1.conn0.child1/highlighter75",
+      "traits": {
+        "autoHideOnDestroy": true
+      }
+    },
+    "from": "server1.conn0.child1/inspectorActor3"
+  },
+  {
+    "nodeFront": {
+      "node": {
+        "actor": "server1.conn0.child1/domnode76",
+        "baseURI": "http://localhost/devtools-demos/console/all.html",
+        "parent": "server1.conn0.child1/domnode77",
+        "nodeType": 1,
+        "namespaceURI": "http://www.w3.org/1999/xhtml",
+        "nodeName": "BUTTON",
+        "numChildren": 1,
+        "singleTextChild": {
+          "actor": "server1.conn0.child1/domnode79",
+          "baseURI": "http://localhost/devtools-demos/console/all.html",
+          "parent": "server1.conn0.child1/domnode76",
+          "nodeType": 3,
+          "namespaceURI": null,
+          "nodeName": "#text",
+          "numChildren": 0,
+          "isBeforePseudoElement": false,
+          "isAfterPseudoElement": false,
+          "isAnonymous": false,
+          "isNativeAnonymous": false,
+          "isXBLAnonymous": false,
+          "isShadowAnonymous": false,
+          "isDisplayed": true,
+          "hasEventListeners": false,
+          "shortValue": "console api"
+        },
+        "name": "",
+        "attrs": [
+          {
+            "name": "id",
+            "value": "consoleAPI"
+          }
+        ],
+        "isBeforePseudoElement": false,
+        "isAfterPseudoElement": false,
+        "isAnonymous": false,
+        "isNativeAnonymous": false,
+        "isXBLAnonymous": false,
+        "isShadowAnonymous": false,
+        "isDisplayed": true,
+        "hasEventListeners": true
+      },
+      "newParents": [
+        {
+          "actor": "server1.conn0.child1/domnode77",
+          "baseURI": "http://localhost/devtools-demos/console/all.html",
+          "parent": "server1.conn0.child1/domnode78",
+          "nodeType": 1,
+          "namespaceURI": "http://www.w3.org/1999/xhtml",
+          "nodeName": "BODY",
+          "numChildren": 74,
+          "attrs": [
+            {
+              "name": "class",
+              "value": "header"
+            }
+          ],
+          "isBeforePseudoElement": false,
+          "isAfterPseudoElement": false,
+          "isAnonymous": false,
+          "isNativeAnonymous": false,
+          "isXBLAnonymous": false,
+          "isShadowAnonymous": false,
+          "isDisplayed": true,
+          "hasEventListeners": false
+        },
+        {
+          "actor": "server1.conn0.child1/domnode78",
+          "baseURI": "http://localhost/devtools-demos/console/all.html",
+          "parent": "server1.conn0.child1/domnode63",
+          "nodeType": 1,
+          "namespaceURI": "http://www.w3.org/1999/xhtml",
+          "nodeName": "HTML",
+          "numChildren": 3,
+          "attrs": [],
+          "isBeforePseudoElement": false,
+          "isAfterPseudoElement": false,
+          "isAnonymous": false,
+          "isNativeAnonymous": false,
+          "isXBLAnonymous": false,
+          "isShadowAnonymous": false,
+          "isDisplayed": true,
+          "hasEventListeners": true,
+          "isDocumentElement": true
+        }
+      ]
+    },
+    "from": "server1.conn0.child1/domwalker64"
+  },
+  {
+    "nodeFront": {
+      "node": {
+        "actor": "server1.conn0.child1/domnode77",
+        "baseURI": "http://localhost/devtools-demos/console/all.html",
+        "parent": "server1.conn0.child1/domnode78",
+        "nodeType": 1,
+        "namespaceURI": "http://www.w3.org/1999/xhtml",
+        "nodeName": "BODY",
+        "numChildren": 74,
+        "attrs": [
+          {
+            "name": "class",
+            "value": "header"
+          }
+        ],
+        "isBeforePseudoElement": false,
+        "isAfterPseudoElement": false,
+        "isAnonymous": false,
+        "isNativeAnonymous": false,
+        "isXBLAnonymous": false,
+        "isShadowAnonymous": false,
+        "isDisplayed": true,
+        "hasEventListeners": false
+      },
+      "newParents": []
+    },
+    "from": "server1.conn0.child1/domwalker64"
+  },
+  {
+    "nodeFront": {
+      "node": {
+        "actor": "server1.conn0.child1/domnode76",
+        "baseURI": "http://localhost/devtools-demos/console/all.html",
+        "parent": "server1.conn0.child1/domnode77",
+        "nodeType": 1,
+        "namespaceURI": "http://www.w3.org/1999/xhtml",
+        "nodeName": "BUTTON",
+        "numChildren": 1,
+        "singleTextChild": {
+          "actor": "server1.conn0.child1/domnode79",
+          "baseURI": "http://localhost/devtools-demos/console/all.html",
+          "parent": "server1.conn0.child1/domnode76",
+          "nodeType": 3,
+          "namespaceURI": null,
+          "nodeName": "#text",
+          "numChildren": 0,
+          "isBeforePseudoElement": false,
+          "isAfterPseudoElement": false,
+          "isAnonymous": false,
+          "isNativeAnonymous": false,
+          "isXBLAnonymous": false,
+          "isShadowAnonymous": false,
+          "isDisplayed": true,
+          "hasEventListeners": false,
+          "shortValue": "console api"
+        },
+        "name": "",
+        "attrs": [
+          {
+            "name": "id",
+            "value": "consoleAPI"
+          }
+        ],
+        "isBeforePseudoElement": false,
+        "isAfterPseudoElement": false,
+        "isAnonymous": false,
+        "isNativeAnonymous": false,
+        "isXBLAnonymous": false,
+        "isShadowAnonymous": false,
+        "isDisplayed": true,
+        "hasEventListeners": true
+      },
+      "newParents": []
+    },
+    "from": "server1.conn0.child1/domwalker64"
+  },
+  {
+    "nodeFront": {
+      "node": {
+        "actor": "server1.conn0.child1/domnode77",
+        "baseURI": "http://localhost/devtools-demos/console/all.html",
+        "parent": "server1.conn0.child1/domnode78",
+        "nodeType": 1,
+        "namespaceURI": "http://www.w3.org/1999/xhtml",
+        "nodeName": "BODY",
+        "numChildren": 74,
+        "attrs": [
+          {
+            "name": "class",
+            "value": "header"
+          }
+        ],
+        "isBeforePseudoElement": false,
+        "isAfterPseudoElement": false,
+        "isAnonymous": false,
+        "isNativeAnonymous": false,
+        "isXBLAnonymous": false,
+        "isShadowAnonymous": false,
+        "isDisplayed": true,
+        "hasEventListeners": false
+      },
+      "newParents": []
+    },
+    "from": "server1.conn0.child1/domwalker64"
+  },
+  {
+    "nodeFront": {
+      "node": {
+        "actor": "server1.conn0.child1/domnode77",
+        "baseURI": "http://localhost/devtools-demos/console/all.html",
+        "parent": "server1.conn0.child1/domnode78",
+        "nodeType": 1,
+        "namespaceURI": "http://www.w3.org/1999/xhtml",
+        "nodeName": "BODY",
+        "numChildren": 74,
+        "attrs": [
+          {
+            "name": "class",
+            "value": "header"
+          }
+        ],
+        "isBeforePseudoElement": false,
+        "isAfterPseudoElement": false,
+        "isAnonymous": false,
+        "isNativeAnonymous": false,
+        "isXBLAnonymous": false,
+        "isShadowAnonymous": false,
+        "isDisplayed": true,
+        "hasEventListeners": false
+      },
+      "newParents": []
+    },
+    "from": "server1.conn0.child1/domwalker64"
+  },
+  {
+    "nodeFront": {
+      "node": {
+        "actor": "server1.conn0.child1/domnode77",
+        "baseURI": "http://localhost/devtools-demos/console/all.html",
+        "parent": "server1.conn0.child1/domnode78",
+        "nodeType": 1,
+        "namespaceURI": "http://www.w3.org/1999/xhtml",
+        "nodeName": "BODY",
+        "numChildren": 74,
+        "attrs": [
+          {
+            "name": "class",
+            "value": "header"
+          }
+        ],
+        "isBeforePseudoElement": false,
+        "isAfterPseudoElement": false,
+        "isAnonymous": false,
+        "isNativeAnonymous": false,
+        "isXBLAnonymous": false,
+        "isShadowAnonymous": false,
+        "isDisplayed": true,
+        "hasEventListeners": false
+      },
+      "newParents": []
+    },
+    "from": "server1.conn0.child1/domwalker64"
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "networkEvent",
+    "eventActor": {
+      "actor": "server1.conn0.child1/netEvent80",
+      "startedDateTime": "2016-02-23T16:27:22.804Z",
+      "timeStamp": 1456244842804,
+      "url": "http://www.mozilla.org/",
+      "method": "GET",
+      "isXHR": true,
+      "private": false
+    }
+  },
+  {
+    "from": "server1.conn0.child1/netEvent80",
+    "type": "networkEventUpdate",
+    "updateType": "requestHeaders",
+    "headers": 8,
+    "headersSize": 384
+  },
+  {
+    "from": "server1.conn0.child1/netEvent80",
+    "type": "networkEventUpdate",
+    "updateType": "requestCookies",
+    "cookies": 0
+  },
+  {
+    "from": "server1.conn0.child1/netEvent80",
+    "type": "networkEventUpdate",
+    "updateType": "eventTimings",
+    "totalTime": 16
+  },
+  {
+    "from": "server1.conn0.child1/netEvent80",
+    "type": "networkEventUpdate",
+    "updateType": "securityInfo",
+    "state": "insecure"
+  },
+  {
+    "from": "server1.conn0.child1/consoleActor2",
+    "type": "consoleAPICall",
+    "message": {
+      "arguments": [
+        "XHR done\n\n: 4"
+      ],
+      "columnNumber": 13,
+      "counter": null,
+      "filename": "http://localhost/devtools-demos/console/all.html",
+      "functionName": "doMyXHR/req.onreadystatechange",
+      "groupName": "",
+      "level": "log",
+      "lineNumber": 338,
+      "private": false,
+      "styles": [],
+      "timeStamp": 1456244842927,
+      "timer": null,
+      "workerType": "none",
+      "category": "webdev"
+    }
+  },
+  {
+    "from": "server1.conn0.child1/netEvent80",
+    "type": "networkEventUpdate",
+    "updateType": "responseContent",
+    "mimeType": "",
+    "contentSize": 0,
+    "encoding": "base64",
+    "transferredSize": null,
+    "discardResponseBody": false
+  }
+]
+
+}
+

--- a/test/data/mock-messages/index.js
+++ b/test/data/mock-messages/index.js
@@ -1,10 +1,12 @@
 import ConsoleGeneric from "./ConsoleGeneric";
 import ConsoleService from "./ConsoleService";
+import MessageStream from "./MessageStream";
 import date from "./Date";
 
 export default {
   ConsoleGeneric,
   ConsoleService,
+  MessageStream,
   JavaScriptEvalOutput: {
       Date: date
   }


### PR DESCRIPTION
Hope this will make implementing individual message types easier.  I've dumped some of the output from https://bgrins.github.io/devtools-demos/console/all.html into mock-messages/MessageStream.js and added a button to the tester component to log them all at once.

We may even want to pre-populate the UI with these messages on startup as we are working through individual message creation to make the workflow faster (no clicks involved) -- although I'm not sure what the best way to do that would be.